### PR TITLE
Startup Sequence Adjustment + Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ https://github.com/user-attachments/assets/27b3cb61-808b-4af2-99aa-c85f0a2a9ecf
 * **ROS 2 Control Integration:** Velocity and Position controllers for precise wheel command.
 * **Dynamic Tracks:** Load CSV based tracks (cones) directly into the simulation.
 * **Interactive Tools:**
-    * `track_gui.py`: Visual track selection and management.
     * `car_dashboard.py`: Real-time vehicle telemetry.
 * **Sensor Simulation:** Simulated Odometry, IMU (via Gazebo plugins), and Cameras.
 
@@ -101,8 +100,26 @@ Open a new terminal and enter:
 ```bash
 source install/setup.bash && ros2 launch bgr_description gazebo.launch.py
 ```
+**Note on Worlds:** You can select different tracks by passing the `world_name` argument. Available worlds:
+* `Acceleration.world` (Default)
+* `Skidpad.world`
+* `TrainingMap.world`
+* `CompetitionMap1.world`, `CompetitionMap2.world`, `CompetitionMap3.world`
+* `CompetitionMapTestday1.world`, `CompetitionMapTestday2.world`, `CompetitionMapTestday3.world`
 
-**Tip:** This also starts the car_dashboard and track_gui automatically.
+**Command to launch a specific world:**
+```bash
+source install/setup.bash && ros2 launch bgr_description gazebo.launch.py world_name:=CompetitionMap1.world
+```
+
+**Headless Mode:**
+If you want to run the simulation without the GUI (e.g., in Docker or on a server), use:
+```bash
+source install/setup.bash && ros2 launch bgr_description gazebo.launch.py headless:=True
+```
+
+
+**Tip:** To run both headless and world, combine both arguments above into the same line (with a space inbetween). Additionally, this also starts the car_dashboard automatically. 
 
 ### Step 2: Activate Controllers
 Once the simulation is running, spawn the ros2_control managers:
@@ -114,7 +131,7 @@ source install/setup.bash && ros2 launch bgr_controller controller.launch.py
 You should see output confirming `joint_state_broadcaster`, `forward_velocity_controller`, and `forward_position_controller` are active.
 
 ### Step 3: Drive the Car (Keyboard Teleop)
-To drive the car using your keyboard, run the teleoperation script:
+To drive the car using your keyboard, run the teleoperation script in order:
 Keyboard setup launcher:
 Open a new terminal and enter:
 ```bash
@@ -144,11 +161,15 @@ source install/setup.bash && ros2 run bgr_controller keyboard_teleop.py
 
 **Gazebo crashes on VM?** Ensure "Accelerate 3D Graphics" is enabled in your VM settings, or try running with `LIBGL_ALWAYS_SOFTWARE=1` if you lack a GPU.
 
+
+> [!IMPORTANT]
+> **Graceful Shutdown:** To ensure all nodes and the simulation state are saved/closed correctly, always shut down your terminals in the **reverse order** they were opened (LIFO/Stack order). Close Step 3 (Teleop), then Step 2 (Controllers), and finally Step 1 (Gazebo).
+
 ---
 
 **Maintained by:** BGRacing Simulator Team
 
-
+---
 
 #  🏎️ Docker Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,156 @@
-# BGR_Simulator
+# 🏎️ BGRacing Driverless Simulator (ROS 2 Jazzy)
+
+![ROS 2 Jazzy](https://img.shields.io/badge/ROS_2-Jazzy-blue?logo=ros&logoColor=white)
+![Gazebo Sim](https://img.shields.io/badge/Simulator-Gazebo_Sim-orange?logo=gazebo&logoColor=white)
+![License](https://img.shields.io/badge/License-MIT-green)
+
+A high-fidelity simulation environment for the **BGRacing Formula Student Team**.
+Built on **ROS 2 Jazzy** and **Gazebo Sim (GZ)**, utilizing `ros2_control` for accurate vehicle dynamics and Ackermann steering.
+
+---
+
+## 📸 Gallery & Demos
+
+### Simulation Environment
+![Simulation View](/doc/Car1.png)
+
+
+### Driving Demo + LiDAR Sim
+
+
+https://github.com/user-attachments/assets/a613b591-cd07-49bc-b930-c8c4ba2a1f91
+
+
+
+### Driving Demo + Localization Sim
+
+https://github.com/user-attachments/assets/27b3cb61-808b-4af2-99aa-c85f0a2a9ecf
+
+
+
+
+---
+
+## 🚀 Features
+
+* **Custom Ackermann Steering:** Realistic geometry with mimic joints for visualization.
+* **ROS 2 Control Integration:** Velocity and Position controllers for precise wheel command.
+* **Dynamic Tracks:** Load CSV based tracks (cones) directly into the simulation.
+* **Interactive Tools:**
+    * `track_gui.py`: Visual track selection and management.
+    * `car_dashboard.py`: Real-time vehicle telemetry.
+* **Sensor Simulation:** Simulated Odometry, IMU (via Gazebo plugins), and Cameras.
+
+---
+
+## 🛠️ Installation & Prerequisites
+
+### 1. System Requirements
+* **OS:** Ubuntu 24.04 LTS (Noble Numbat)
+* **ROS:** ROS 2 Jazzy Jalisco
+
+### 2. Install Dependencies
+Run the following commands to install all necessary packages for ROS 2 Jazzy and Gazebo:
+
+```bash
+sudo apt update
+sudo apt install -y \
+    ros-jazzy-ros2-control \
+    ros-jazzy-ros2-controllers \
+    ros-jazzy-xacro \
+    ros-jazzy-ros-gz-* \
+    ros-jazzy-*-ros2-control \
+    ros-jazzy-joint-state-publisher-gui \
+    ros-jazzy-turtlesim \
+    ros-jazzy-robot-localization \
+    ros-jazzy-joy \
+    ros-jazzy-joy-teleop \
+    ros-jazzy-tf-transformations
+```
+
+### 3. Clone & Build
+Create a workspace and clone the repository:
+
+```bash
+mkdir -p ~/bgr_ws/src
+cd ~/bgr_ws/src
+git clone https://github.com/shaharhalevi/bgr_simulator.git .
+```
+
+Install python dependencies (if any) and build the workspace:
+
+```bash
+cd ~/bgr_ws
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --symlink-install
+```
+
+---
+
+## 🏁 How to Run
+
+Open separate terminals for each step (or use functionality like Tmux/Terminator). Always source your workspace in every new terminal:
+
+```bash
+source install/setup.bash
+```
+
+### Step 1: Launch the Simulation
+This loads the track, the robot model (bgr_description), and the Gazebo environment.
+Open a new terminal and enter:
+```bash
+source install/setup.bash && ros2 launch bgr_description gazebo.launch.py
+```
+
+**Tip:** This also starts the car_dashboard and track_gui automatically.
+
+### Step 2: Activate Controllers
+Once the simulation is running, spawn the ros2_control managers:
+Open a new terminal and enter:
+```bash
+source install/setup.bash && ros2 launch bgr_controller controller.launch.py
+```
+
+You should see output confirming `joint_state_broadcaster`, `forward_velocity_controller`, and `forward_position_controller` are active.
+
+### Step 3: Drive the Car (Keyboard Teleop)
+To drive the car using your keyboard, run the teleoperation script:
+Keyboard setup launcher:
+Open a new terminal and enter:
+```bash
+source install/setup.bash && ros2 launch bgr_controller keyboard_teleop.launch.py
+```
+Keyboard activation:
+Open a new terminal and enter:
+```bash
+source install/setup.bash && ros2 run bgr_controller keyboard_teleop.py
+```
+
+**Controls:**
+- Use **Arrow Keys** or **WASD** to control the car
+- **Space** to brake/stop
+- **Q** to quit the teleop node
+- Ensure the terminal running the script has focus for keyboard input to work
+
+---
+
+---
+
+## 🔧 Troubleshooting
+
+**Robot not moving?** Ensure you ran Step 2 (Controllers). The robot won't respond to commands if the controllers aren't spawned.
+
+**Missing Models?** Ensure the environment variable `GZ_SIM_RESOURCE_PATH` is set correctly. The launch file handles this, but if you moved folders manually, check `gazebo.launch.py`.
+
+**Gazebo crashes on VM?** Ensure "Accelerate 3D Graphics" is enabled in your VM settings, or try running with `LIBGL_ALWAYS_SOFTWARE=1` if you lack a GPU.
+
+---
+
+**Maintained by:** BGRacing Simulator Team
+
+
+
+#  🏎️ Docker Setup
 
 This package contains the Gazebo harmonic simulation environment for the BGRacing car. It includes the URDF/Xacro robot descriptions, Gazebo worlds, custom dashboards, and the ROS 2 bridge configurations necessary to expose simulated hardware to the rest of the autonomy stack.
 
@@ -236,7 +388,7 @@ This will return an array of `Cone` messages containing the `(x, y)` coordinates
    pkill -9 -f "gz sim"
    pkill -9 -f "ros_gz"
    pkill -9 -f "robot_state_publisher"
+   killall -9 gz ros2 rviz2 ruby
    ```
 
 ---
-

--- a/src/bgr_description/launch/gazebo.launch.py
+++ b/src/bgr_description/launch/gazebo.launch.py
@@ -6,9 +6,10 @@ Unlike gazebo.launch.py (which uses blind TimerActions), this file uses
 Readiness Verification Gates: each stage only fires when the previous one
 is *actually* ready, not after an arbitrary fixed delay.
 
-Stage 1 → Gazebo + Bridge start. Gate: wait for /clock.
-Stage 2 → Vehicle spawns.         Gate: wait for /model/bgr/odometry.
-Stage 3 → All tooling launches.   Gate: GUI tracker retry-loop.
+Stage 1 → Gazebo + Clock Bridge. Gate: wait for /clock.
+Stage 2 → GUI readiness check.   Gate: wait for /gui/ services.
+Stage 3 → Vehicle + Sensor Bridge. Gate: wait for /model/bgr/odometry.
+Stage 4 → All tooling launches.   Gate: GUI tracker retry-loop.
 """
 
 import os
@@ -140,54 +141,53 @@ def generate_launch_description():
         output='screen'
     )
 
-    # STAGE 1.5 GATE: GUI READINESS
+    # STAGE 2 GATE: GUI READINESS
     # Deterministically waits for the Gazebo GUI to finish initializing its rendering 
     # pipeline by checking for the existence of /gui/ services.
     gui_ready_gate = ExecuteProcess(
         cmd=['sh', '-c', 
              'if [ "$1" = "True" ] || [ "$1" = "true" ] || [ "$1" = "1" ]; then '
-             '  echo "[STAGE 1.5] Headless mode detected. Skipping GUI readiness check."; '
+             '  echo "[STAGE 2] Headless mode detected. Skipping GUI readiness check."; '
              '  exit 0; '
              'fi; '
-             'echo "[STAGE 1.5] Waiting for Gazebo GUI services to initialize..."; '
+             'echo "[STAGE 2] Waiting for Gazebo GUI services to initialize..."; '
              'for i in $(seq 1 60); do '
              '  if gz service -l | grep -q "/gui/"; then '
-             '    echo "[STAGE 1.5 COMPLETE] Gazebo GUI is ready."; '
+             '    echo "[STAGE 2 COMPLETE] Gazebo GUI is ready."; '
              '    exit 0; '
              '  fi; '
              '  sleep 1; '
              'done; '
-             'echo "[STAGE 1.5 WARNING] GUI services not found after 60s. Proceeding anyway..."; '
+             'echo "[STAGE 2 WARNING] GUI services not found after 60s. Proceeding anyway..."; '
              'exit 0;',
              'gui_gate_script', headless],
         output='screen'
     )
 
-    # STAGE 2: VEHICLE SPAWN
-    # Activates immediately upon Stage 1 completion.
-    gz_spawn_entity = Node(
-        package="ros_gz_sim",
-        executable="create",
-        output="screen",
-        arguments=[
-            "-world", "generated_world",
-            "-topic", "robot_description",
-            "-name", "bgr",
-            "-x", "0.0",
-            "-y", "0.0",
-            "-z", "1",
-        ],
+    # STAGE 3: VEHICLE SPAWN
+    # Activates immediately upon Stage 2 completion.
+    # Wraps the spawn command in a retry loop to prevent timeouts on slow hardware
+    # when loading heavy worlds (like CompetitionMap1.world).
+    gz_spawn_entity = ExecuteProcess(
+        cmd=['bash', '-c',
+             'for i in $(seq 1 30); do '
+             'echo "[STAGE 3] Attempting to spawn vehicle..." && '
+             'ros2 run ros_gz_sim create -world generated_world -topic robot_description -name bgr -x 0.0 -y 0.0 -z 1 && '
+             'echo "[STAGE 3 SUCCESS] Vehicle spawn request accepted!" && break; '
+             'echo "[STAGE 3 WARNING] Spawn request timed out or failed. Gazebo is busy loading world. Retrying in 2s..." && '
+             'sleep 2; done'],
+        output='screen'
     )
 
-    # STAGE 2 GATE
+    # STAGE 3 GATE
     # Blocks until the vehicle's odometry topic starts publishing.
     # This happens once the URDF loaded into the Gazebo.
-    stage2_gate = ExecuteProcess(
+    stage3_gate = ExecuteProcess(
         cmd=['python3', '-c', "import rclpy; from nav_msgs.msg import Odometry; rclpy.init(); node=rclpy.create_node('gate'); node.create_subscription(Odometry, '/model/bgr/odometry', lambda msg: exit(0), 1); rclpy.spin(node)"],
         output='screen'
     )
 
-    # STAGE 3 NODES
+    # STAGE 4 NODES
     # Originally all nodes fired at once. Now the car nodes fire up only after
     # the previous stages completed, making sure the car physically exists.
     car_state_node = Node(
@@ -259,32 +259,32 @@ def generate_launch_description():
     # Each RegisterEventHandler watches for it's designated process to exit and
     # then executes the next step.
 
-    # Stage 1 → Stage 1.5: once /clock >= 0.1s, start checking for GUI.
-    stage1_to_stage15 = RegisterEventHandler(
+    # Stage 1 → Stage 2: once /clock >= 0.1s, start checking for GUI.
+    stage1_to_stage2 = RegisterEventHandler(
         OnProcessExit(
             target_action=stage1_gate,
             on_exit=[gui_ready_gate]
         )
     )
 
-    # Stage 1.5 → Stage 2: once GUI is ready (or skipped), spawn vehicle.
-    stage15_to_stage2 = RegisterEventHandler(
+    # Stage 2 → Stage 3: once GUI is ready (or skipped), spawn vehicle and sensor bridge.
+    stage2_to_stage3 = RegisterEventHandler(
         OnProcessExit(
             target_action=gui_ready_gate,
             on_exit=[
-                LogInfo(msg='[STAGE 2 START] Spawning vehicle and monitoring odometry...'),
+                LogInfo(msg='[STAGE 3 START] Spawning vehicle and monitoring odometry...'),
                 gz_spawn_entity,
-                stage2_gate,
+                stage3_gate,
             ]
         )
     )
 
-    # Stage 2 → Stage 3: when odometry appears, launch the car related nodes.
-    stage2_to_stage3 = RegisterEventHandler(
+    # Stage 3 → Stage 4: when odometry appears, launch the car related nodes.
+    stage3_to_stage4 = RegisterEventHandler(
         OnProcessExit(
-            target_action=stage2_gate,
+            target_action=stage3_gate,
             on_exit=[
-                LogInfo(msg='[STAGE 3 START] Vehicle is responsive. Launching tooling...'),
+                LogInfo(msg='[STAGE 4 START] Vehicle is responsive. Launching tooling...'),
                 car_state_node,                 # starts the car state publisher node
                 car_wheel_node,                 # starts the car wheel publisher node
                 car_dashboard_node,             # starts the car dashboard GUI node
@@ -308,7 +308,7 @@ def generate_launch_description():
         gazebo,                     # starts the simulator
         gz_ros2_bridge,             # bridges /clock and sensor topics
         stage1_gate,                # starts immediately, watches for /clock
-        stage1_to_stage15,          # chains Stage 1 → Stage 1.5
-        stage15_to_stage2,          # chains Stage 1.5 → Stage 2
-        stage2_to_stage3,           # chains Stage 2 → Stage 3 on odometry ready
+        stage1_to_stage2,           # chains Stage 1 → Stage 2
+        stage2_to_stage3,           # chains Stage 2 → Stage 3
+        stage3_to_stage4,           # chains Stage 3 → Stage 4 on odometry ready
     ])


### PR DESCRIPTION
Renamed the startup sequence from stages 1,1.5,2,3 to stages 1,2,3,4 (for readability)
Previously, the car spawn entity was a node service that launched once, causing a major problem when gazebo was loading a heavy world, by sending a request to spawn the vehicle and being timed out.
Now, the car spawn entity is a process that continuously tries to launch the vehicle until a successful attempt has been reached. This means that even a slow laptop will load any world, regardless of its size, correctly (Barring extreme circumstances)

Updated README to include what was in the previous commit, and updating it to include relevant commands and description to the current state of the code.